### PR TITLE
Adicionando decorator que impede o armazenamento das paginas em cache 

### DIFF
--- a/project/api/views.py
+++ b/project/api/views.py
@@ -10,6 +10,16 @@ pax_blueprint = Blueprint('pax', __name__)
 db = Singleton().database_connection()
 utils = Utils()
 
+@pax_blueprint.after_request
+def add_header(r):
+    """
+    Adding headers to prevent page caching
+    """
+    r.headers["Cache-Control"] = "no-cache, no-store, must-revalidate, public, max-age=0"
+    r.headers["Pragma"] = "no-cache"
+    r.headers["Expires"] = "0"
+    return r
+
 
 @pax_blueprint.route('/upCreate', methods=['POST'])
 def upCreate():


### PR DESCRIPTION
# Descrição
Como o cache tem causado problemas no uso do microsserviço, esse PR adiciona um decorator que é executado sempre após todo request feito na rota. A função decorada por esse decorator adiciona headers ao request que inibem o cache.

# Tipo de Mudanças

- [ ] História de Usuário
- [X] Historia Técnica
- [ ] Wiki

# Responsáveis pela revisão
@rogerioo 